### PR TITLE
[CM-1252] Add layout to set edge insets

### DIFF
--- a/Sources/YStepper/SwiftUI/Views/Stepper.swift
+++ b/Sources/YStepper/SwiftUI/Views/Stepper.swift
@@ -133,7 +133,7 @@ extension Stepper: View {
 
     @ViewBuilder
     func getShape() -> some View {
-        switch appearance.shape {
+        switch appearance.layout.shape {
         case .none:
             EmptyView()
         case .rectangle:
@@ -159,7 +159,7 @@ extension Stepper: View {
 
     @ViewBuilder
     func getShapeWithoutStroke() -> some View {
-        switch appearance.shape {
+        switch appearance.layout.shape {
         case .none:
             EmptyView()
         case .rectangle:

--- a/Sources/YStepper/UIKit/StepperControl+Appearance+Layout.swift
+++ b/Sources/YStepper/UIKit/StepperControl+Appearance+Layout.swift
@@ -9,28 +9,33 @@
 import UIKit
 
 extension StepperControl.Appearance {
-    /// A collection of layout properties for the `StepperControl`.
+    /// A collection of layout properties for the `StepperControl`
     public struct Layout: Equatable {
-        /// The content inset from edges.
+        /// The content inset from edges. Stepper "content" consists of the two buttons and the text label between them.
         /// Default is `{8, 16, 8, 16}`.
         public var contentInset: NSDirectionalEdgeInsets
-        /// The minimum required horizontal spacing between icons and label. Default is `8.0`.
+        /// The horizontal spacing between the stepper buttons and label. Default is `8.0`
         public var gap: CGFloat
+        /// Stepper's shape
+        public var shape: Shape
 
-        /// Default StepperControl view layout.
+        /// Default stepper control layout.
         public static let `default` = Layout()
 
         /// Initializes a `Layout`.
         /// - Parameters:
-        ///   - contentInset: content inset from edges.
-        ///   - gap: horizontal spacing between icons and label.
+        ///   - contentInset: content inset from edges
+        ///   - gap: horizontal spacing between icons and label
+        ///   - shape: Stepper's shape. Default is `.capsule`
         public init(
             contentInset: NSDirectionalEdgeInsets =
             NSDirectionalEdgeInsets(topAndBottom: 8, leadingAndTrailing: 16),
-            gap: CGFloat = 8
+            gap: CGFloat = 8,
+            shape: Shape = .capsule
         ) {
             self.contentInset = contentInset
             self.gap = gap
+            self.shape = shape
         }
     }
 }

--- a/Sources/YStepper/UIKit/StepperControl+Appearance.swift
+++ b/Sources/YStepper/UIKit/StepperControl+Appearance.swift
@@ -26,8 +26,6 @@ extension StepperControl {
         public var incrementImage: UIImage
         /// Decrement button image
         public var decrementImage: UIImage
-        /// Stepper's shape
-        public var shape: Shape
         /// Stepper's layout properties such as spacing between views. Default is `.default`
         public var layout: Layout
         /// Whether to show delete button or not
@@ -44,7 +42,6 @@ extension StepperControl {
         ///   - deleteImage: Delete button image. Default is `Appearance.defaultDeleteImage`
         ///   - incrementImage: Increment button image. Default is `Appearance.defaultIncrementImage`
         ///   - decrementImage: Decrement button image. Default is `Appearance.defaultDecrementImage`
-        ///   - shape: Stepper's shape. Default is `.capsule`
         ///   - layout: Stepper's layout properties like spacing between views
         
         public init(
@@ -56,7 +53,6 @@ extension StepperControl {
             deleteImage: UIImage? = Appearance.defaultDeleteImage,
             incrementImage: UIImage = Appearance.defaultIncrementImage,
             decrementImage: UIImage = Appearance.defaultDecrementImage,
-            shape: Shape = .capsule,
             layout: Layout = .default
         ) {
             self.textStyle = textStyle
@@ -66,7 +62,6 @@ extension StepperControl {
             self.deleteImage = deleteImage
             self.incrementImage = incrementImage
             self.decrementImage = decrementImage
-            self.shape = shape
             self.layout = layout
         }
     }

--- a/Tests/YStepperTests/Views/StepperTests.swift
+++ b/Tests/YStepperTests/Views/StepperTests.swift
@@ -153,76 +153,84 @@ final class StepperTests: XCTestCase {
     }
 
     func testShapesNotNil() {
-        var expectedAppearance = StepperControl.Appearance(shape: .rectangle)
+        var expectedAppearance = StepperControl.Appearance(layout: StepperControl.Appearance.Layout(shape: .rectangle))
         var sut = makeSUT(appearance: expectedAppearance)
         let rectShape = sut.getShape()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(rectShape)
 
-        expectedAppearance = StepperControl.Appearance(shape: .roundRect(cornerRadius: 10))
+        expectedAppearance = StepperControl.Appearance(
+            layout: StepperControl.Appearance.Layout(shape: .roundRect(cornerRadius: 10))
+        )
         sut.appearance = expectedAppearance
         let roundedRectShape = sut.getShape()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(roundedRectShape)
 
-        expectedAppearance = StepperControl.Appearance(shape: .scaledRoundRect(cornerRadius: 10))
+        expectedAppearance = StepperControl.Appearance(
+            layout: StepperControl.Appearance.Layout(shape: .scaledRoundRect(cornerRadius: 10))
+        )
         sut.appearance = expectedAppearance
         let scaledRoundRect = sut.getShape()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(scaledRoundRect)
 
-        expectedAppearance = StepperControl.Appearance(shape: .capsule)
+        expectedAppearance = StepperControl.Appearance(layout: StepperControl.Appearance.Layout(shape: .capsule))
         sut.appearance = expectedAppearance
         let capsuleShape = sut.getShape()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(capsuleShape)
 
-        expectedAppearance = StepperControl.Appearance(shape: .none)
+        expectedAppearance = StepperControl.Appearance(layout: StepperControl.Appearance.Layout(shape: .none))
         sut.appearance = expectedAppearance
         let emptyView = sut.getShape()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(emptyView)
     }
 
     func testShapesWithoutStrokeNotNil() {
-        var expectedAppearance = StepperControl.Appearance(shape: .rectangle)
+        var expectedAppearance = StepperControl.Appearance(layout: StepperControl.Appearance.Layout(shape: .rectangle))
         var sut = makeSUT(appearance: expectedAppearance)
         let rectShape = sut.getShapeWithoutStroke()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(rectShape)
 
-        expectedAppearance = StepperControl.Appearance(shape: .roundRect(cornerRadius: 10))
+        expectedAppearance = StepperControl.Appearance(
+            layout: StepperControl.Appearance.Layout(shape: .roundRect(cornerRadius: 10))
+        )
         sut.appearance = expectedAppearance
         let roundedRectShape = sut.getShapeWithoutStroke()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(roundedRectShape)
 
-        expectedAppearance = StepperControl.Appearance(shape: .scaledRoundRect(cornerRadius: 10))
+        expectedAppearance = StepperControl.Appearance(
+            layout: StepperControl.Appearance.Layout(shape: .scaledRoundRect(cornerRadius: 10))
+        )
         sut.appearance = expectedAppearance
         let scaledRoundRect = sut.getShapeWithoutStroke()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(scaledRoundRect)
 
-        expectedAppearance = StepperControl.Appearance(shape: .capsule)
+        expectedAppearance = StepperControl.Appearance(layout: StepperControl.Appearance.Layout(shape: .capsule))
         sut.appearance = expectedAppearance
         let capsuleShape = sut.getShapeWithoutStroke()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(capsuleShape)
 
-        expectedAppearance = StepperControl.Appearance(shape: .none)
+        expectedAppearance = StepperControl.Appearance(layout: StepperControl.Appearance.Layout(shape: .none))
         sut.appearance = expectedAppearance
         let emptyView = sut.getShapeWithoutStroke()
 
-        XCTAssertEqual(sut.appearance.shape, expectedAppearance.shape)
+        XCTAssertEqual(sut.appearance.layout.shape, expectedAppearance.layout.shape)
         XCTAssertNotNil(emptyView)
     }
 


### PR DESCRIPTION
## Introduction ##

User should be able to provide insets for Stepper.
## Purpose ##

Now edge insets are part of appearance so that user can change the insets for Stepper.

## 📱 Screenshots ##

Default edges
<img width="613" alt="Default insets" src="https://user-images.githubusercontent.com/111066844/226338006-59edd44a-b3c0-4a05-a287-5a43a3517be0.png">

<img width="130" alt="Default UI" src="https://user-images.githubusercontent.com/111066844/226338046-7038af9c-b889-4115-b11f-600837025217.png">

Custom edges
<img width="623" alt="Screenshot 2023-03-20 at 5 52 29 PM" src="https://user-images.githubusercontent.com/111066844/226338184-fc2361ec-7ce2-41bc-bba6-03976bcdb859.png">

<img width="129" alt="Custom UI" src="https://user-images.githubusercontent.com/111066844/226338213-0d832d7e-7e2e-4462-9154-3da7b6bcfca6.png">

## 📈 Coverage ##

##### Code #####

Code coverage is ~97.5%
<img width="1409" alt="Code coverage" src="https://user-images.githubusercontent.com/111066844/226337214-3ef707b2-2469-487e-ba81-8bd259f6981e.png">

##### Documentation #####

Public apis are 100% documented.
<img width="564" alt="Jazzy report" src="https://user-images.githubusercontent.com/111066844/226337431-c40ad8a7-0779-4f10-98e4-7632361c1667.png">
