### PR TITLE
[CM-1262] showDeleteImage is now public

### DIFF
--- a/Sources/YStepper/UIKit/StepperControl+Appearance.swift
+++ b/Sources/YStepper/UIKit/StepperControl+Appearance.swift
@@ -29,7 +29,7 @@ extension StepperControl {
         /// Stepper's layout properties such as spacing between views. Default is `.default`.
         public var layout: Layout
         /// Whether to show delete image or not.
-        var showDeleteImage: Bool
+        public var showDeleteImage: Bool
 
         /// Initializer for appearance.
         /// - Parameters:


### PR DESCRIPTION
## Introduction ##

Change access of showDeleteImage from internal to public
## Purpose ##

Make showDeleteImage public.
Fix https://github.com/yml-org/ystepper-ios/issues/9.

## 📈 Coverage ##

##### Code #####

No change in code coverage.
##### Documentation #####

No change in documentation.