### PR TITLE
Add SPI shields to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Y—Stepper](https://user-images.githubusercontent.com/1037520/227443013-4bd3b22f-49fa-4f28-bd86-013367a389f4.jpeg)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyml-org%2Fystepper-ios%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/yml-org/ystepper-ios) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyml-org%2Fystepper-ios%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/yml-org/ystepper-ios)  
 _Accessible and customizable shopping cart-style stepper for iOS._
 
 ![YStepper](https://user-images.githubusercontent.com/111066844/228565950-f4a7258f-0f87-48cf-b004-d77bacf81d4b.gif)


### PR DESCRIPTION
## Introduction ##

All our open source projects should make use of Shields to provide useful realtime information about the project.

## Purpose ##

Fix #17 
Add Swift version and Platform shields to the top of our README

## Scope ##

Add one line to the README file

## 📱 Screenshots ##

<img width="973" alt="image" src="https://user-images.githubusercontent.com/1037520/228748734-8822ce17-698d-4735-82f2-35dd765d5e3c.png">

## 📈 Coverage ##

Code and documentation coverage remain unchanged (at 100%)
