### PR TITLE
[CM-1334] Remove compiler warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // For UI layout support, contrast ratio calculations.
-        .package(url: "https://github.com/yml-org/YCoreUI.git", from: "1.6.0"),
+        .package(url: "https://github.com/yml-org/YCoreUI.git", from: "1.7.0"),
         // For Typography support
         .package(url: "https://github.com/yml-org/YMatterType.git", from: "1.6.0")
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // For UI layout support, contrast ratio calculations.
-        .package(url: "https://github.com/yml-org/YCoreUI.git", from: "1.5.0"),
+        .package(url: "https://github.com/yml-org/YCoreUI.git", from: "1.6.0"),
         // For Typography support
         .package(url: "https://github.com/yml-org/YMatterType.git", from: "1.6.0")
     ],

--- a/Sources/YStepper/UIKit/StepperControl+Appearance+Layout.swift
+++ b/Sources/YStepper/UIKit/StepperControl+Appearance+Layout.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import YCoreUI
 
 extension StepperControl.Appearance {
     /// A collection of layout properties for the `StepperControl`.


### PR DESCRIPTION
## Introduction ##

Remove compiler warn introduced due to update in Swift.
## Purpose ##

Update file `StepperControl+Appearance+Layout.swift` according to latest Swift version.
Fix https://github.com/yml-org/ystepper-ios/issues/19
## Scope ##

Update file `StepperControl+Appearance+Layout.swift`
## Out of Scope ##

Any functionality or UI changes.
## 📈 Coverage ##

##### Code #####

No change.
##### Documentation #####

No change.