### PR TITLE
[CM-1333] Update system image

### DIFF
--- a/Sources/YStepper/UIKit/StepperControl+Appearance.swift
+++ b/Sources/YStepper/UIKit/StepperControl+Appearance.swift
@@ -77,9 +77,9 @@ extension StepperControl.Appearance {
     ///  Default stepper appearance
     public static let `default` = StepperControl.Appearance()
     /// Default image for delete button. Is a `trash` from SF Symbols in template rendering mode.
-    public static let defaultDeleteImage = StepperControl.Images.delete.image.withRenderingMode(.alwaysTemplate)
+    public static let defaultDeleteImage = StepperControl.Images.delete.image
     /// Default image for increment button. Is a `plus` from SF Symbols in template rendering mode.
-    public static let defaultIncrementImage = StepperControl.Images.increment.image.withRenderingMode(.alwaysTemplate)
+    public static let defaultIncrementImage = StepperControl.Images.increment.image
     /// Default image for decrement button. Is a `minus` from SF Symbols in template rendering mode.
-    public static let defaultDecrementImage = StepperControl.Images.decrement.image.withRenderingMode(.alwaysTemplate)
+    public static let defaultDecrementImage = StepperControl.Images.decrement.image
 }

--- a/Sources/YStepper/UIKit/StepperControl.swift
+++ b/Sources/YStepper/UIKit/StepperControl.swift
@@ -87,6 +87,8 @@ extension StepperControl {
         case increment = "plus"
         case decrement = "minus"
         case delete = "trash"
+
+        public static var renderingMode: UIImage.RenderingMode { .alwaysTemplate }
     }
 }
 

--- a/Tests/YStepperTests/Classes/StepperControlTests.swift
+++ b/Tests/YStepperTests/Classes/StepperControlTests.swift
@@ -29,6 +29,12 @@ final class StepperControlTests: XCTestCase {
         XCTAssertEqual(sut.appearance.incrementImage, defaultAppearance.incrementImage)
     }
 
+    func test_renderMode_deliversCorrectMode() {
+        StepperControl.Images.allCases.forEach {
+            XCTAssertEqual($0.image.renderingMode, .alwaysTemplate)
+        }
+    }
+
     func testCustomeAppearance() {
         let customeAppearance = StepperControl.Appearance(textStyle: (textColor: .red, typography: .systemButton))
         let sut = makeSUT(appearance: customeAppearance)


### PR DESCRIPTION
## Introduction ##

Add override of renderingMode to `StepperControl.Images` and return `.alwaysTemplate`.
## Purpose ##

to use rending mode with system image instead in `StepperControl.Images` .
Fix https://github.com/yml-org/ystepper-ios/issues/20
## Scope ##

Default increment, decrement and delete image.
## Out of Scope ##

Any functionality or UI change.

## 🎬 Video ##

[Same as Screenshots above.
](https://user-images.githubusercontent.com/111066844/231330036-446195df-c35b-408b-b017-695343f07075.mov)
## 📈 Coverage ##

##### Code #####

~96.5%
<img width="1044" alt="coverage" src="https://user-images.githubusercontent.com/111066844/231329934-877f2cdb-0666-4498-be21-72f71fe8e440.png">

##### Documentation #####

100%
<img width="568" alt="Jazzy" src="https://user-images.githubusercontent.com/111066844/231329989-222b0d15-424c-459b-9aed-f19ffee3150c.png">
